### PR TITLE
Introduce logger.promise method for wrapping the Ora library.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/blackbaud/skyux-logger#readme",
   "dependencies": {
+    "ora": "3.0.0",
     "minimist": "1.2.0",
     "winston": "2.4.0"
   },

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,6 +1,7 @@
 /*jshint node: true */
 'use strict';
 
+const ora = require('ora');
 const winston = require('winston');
 const minimist = require('minimist');
 
@@ -32,6 +33,9 @@ const logger = new winston.Logger({
     })
   ]
 });
+
+// Expose ora logger
+logger.promise = (message) => ora(message).start();
 
 // Expose this logic to others
 logger.logColor = logColor;

--- a/test/logger.spec.js
+++ b/test/logger.spec.js
@@ -66,4 +66,27 @@ describe('logger', () => {
     expect(logger.logLevel).toBe('verbose');
     expect(logger.logColor).toBe(false);
   });
+
+  it('should expose a promise that calls in to the ora library', () => {
+    const spyOra = jasmine.createSpy('ora');
+    const spyOraStart = jasmine.createSpyObj('ora', ['start']);
+    const spyOraReturn = jasmine.createSpyObj(
+      'ora',
+      [
+        'fail',
+        'succeed'
+      ]
+    );
+
+    spyOra.and.returnValue(spyOraStart);
+    spyOraStart.start.and.returnValue(spyOraReturn);
+    mock('ora', spyOra);
+
+    const message = 'test-message';
+    const logger = mock.reRequire('../src/logger');
+    const response = logger.promise(message);
+
+    expect(response.succeed).toBeDefined();
+    expect(response.fail).toBeDefined();
+  });
 });


### PR DESCRIPTION
Migrated some of the concise logging behavior from https://github.com/blackbaud/skyux-cli/pull/158 by exposing a `logger.promise` method.  This method returns an object with an `succeed` and `fail` method.  This mirrors the `Ora` library's API.

The benefit to wrapping this functionality here (as first proposed by @Blackbaud-SteveBrush) is that all consumers of `@blackbaud/skyux-logger` get the functionality for free.